### PR TITLE
chore: Disable targets for cross-compilation.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,6 +8,7 @@ haskell_library(
     name = "hs-apigen",
     srcs = glob(["src/**/*.*hs"]),
     src_strip_prefix = "src",
+    tags = ["no-cross"],
     version = "0.0.2",
     visibility = ["//visibility:public"],
     deps = [

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_haskell//haskell:defs.bzl", "haskell_binary")
 haskell_binary(
     name = "apigen",
     srcs = ["apigen.hs"],
+    tags = ["no-cross"],
     visibility = ["//visibility:public"],
     deps = [
         "//hs-apigen",


### PR DESCRIPTION
This way we can do bazel build //... when cross-compiling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-apigen/5)
<!-- Reviewable:end -->
