### PR TITLE
fix: Use `__del__` instead of `__dealloc__`.

### DIFF
--- a/tools/gen-python
+++ b/tools/gen-python
@@ -613,7 +613,7 @@ class GenCython:
             f"            raise common.UseAfterFreeException()",
             f"        return self._ptr",
             "",
-            f"    def __dealloc__(self) -> None:",
+            f"    def __del__(self) -> None:",
             f"        self.__exit__(None, None, None)",
             "",
             f"    def __enter__(self: T) -> T:",


### PR DESCRIPTION
It's safer. In dealloc, the object state can be invalid.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-apigen/15)
<!-- Reviewable:end -->
